### PR TITLE
PANarchy

### DIFF
--- a/lib/fullccnum.js
+++ b/lib/fullccnum.js
@@ -20,7 +20,7 @@ Fullccnum.scrubNonDigits = function (raw) {
  * Use this regular expression to look for card numbers in arbitrary text
  * when you don't want to accidentally pick up numbers in longer strings of digits
  */
-Fullccnum.cardNumberRegex = /\D(\d{13,16})\D/g;
+Fullccnum.cardNumberRegex = /\D(\d{13,19})\D/g;
 
 /**
  * Produces a list of strings of digits in a text that look like card numbers.
@@ -39,7 +39,7 @@ Fullccnum.cardNumbersInText = function(text) {
 Fullccnum.isValid = function(ccnum) {
   return (ccnum &&
     typeof ccnum === 'string' &&
-    !!ccnum.match(/^\d{13,16}$/) &&   // Only 13-16 digits
+    !!ccnum.match(/^\d{13,19}$/) &&   // Only 13-19 digits
     Fullccnum.passesLuhnCode(ccnum));
 };
 

--- a/test/fullccnum-test.js
+++ b/test/fullccnum-test.js
@@ -51,6 +51,11 @@ describe('Fullccnum', function() {
     it('should find the card number but not the tx', function() {
       const sampleText = '<card>348771682068975</card><txid>41111111111111111111</txid><unrelated>4111111111111112</unrelated>';
       Fullccnum.cardNumbersInText(sampleText).should.eql(['348771682068975']);
+    });
+
+    it('should find a 19-digit card number but not the tx', function () {
+      const sampleText = '<card>4716952655639547799</card><txid>41111111111111111111</txid><unrelated>4111111111111112</unrelated>';
+      Fullccnum.cardNumbersInText(sampleText).should.eql(['4716952655639547799']);
     })
   });
 
@@ -68,6 +73,12 @@ describe('Fullccnum', function() {
         });
       });
 
+      describe('a valid 19-digit Visa number', function () {
+        it('should return true', function () {
+          Fullccnum.isValid('4716952655639547799').should.be.true;
+        });
+      });
+
       describe('checking lower limit', function() {
         it('should verify at least 13 digits', function() {
           Fullccnum.isValid('111111111212').should.be.false;
@@ -76,9 +87,9 @@ describe('Fullccnum', function() {
       });
 
       describe('checking the upper limit', function() {
-        it('should verify no more than 16 digits', function() {
+        it('should verify no more than 19 digits', function() {
           Fullccnum.isValid('4111111111111111').should.be.true;
-          Fullccnum.isValid('41111111111111121').should.be.false;
+          Fullccnum.isValid('41111111111111121234').should.be.false;
         });
       });
     });


### PR DESCRIPTION
This adds support for up to 19-digit PANs, which are coming sometime in the nearish future: https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2016/november/prepare-for-19-digit-credit-cards/

Questions for reviewers:

* Anything I missed?  I couldn't find any other places in here making assumptions about length of PANs but I might have missed something.
* The `cardNumbersInText` function might accidentally change behavior here, if a 17-19 digit string in some text happens to pass the Luhn algorithm.  Are we ok with that potential breaking change?